### PR TITLE
Run containers detached

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,4 +13,7 @@ jobs:
           rev: dev-main
 
       - name: Start docker containers
-        run: sudo docker compose -f ./docker-compose-server.yml up --build
+        run: sudo docker compose -f ./docker-compose-server.yml up -d --build
+
+      - name: Clean up unused images
+        run: sudo docker image prune -f


### PR DESCRIPTION
Edit deployment workflow to run containers detached. 
This stops the action running infinitely as long as the containers are running. 

Also prune unused docker images after starting the containers. 